### PR TITLE
Fix Docker CI: use GITHUB_TOKEN for GHCR login

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -31,8 +31,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Problem

The Docker build workflow has **never run successfully** — all 3 historical runs failed at the GHCR login step with `##[error]Password required`. The step referenced `secrets.GHCR_PAT`, which was never added to the repo (only `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` exist). Because no image was ever pushed by CI, production is serving a stale, manually-built image (the old viz).

## Fix

- Authenticate to `ghcr.io` with the built-in `GITHUB_TOKEN` instead of the missing `GHCR_PAT`. The job already grants `packages: write`, so no PAT secret is needed.
- Bump `actions/checkout` v4 → v5 to clear the Node 20 deprecation warning.

## Validation

- YAML parses cleanly.
- On this PR, the workflow runs but `push: false` for pull requests, so it's a safe dry run of the login/build (no image shipped until merged to master).

## Notes (not addressed here)

- This builds master's Streamlit `app1.py`. The Taipy rewrite on `refactor/streamlit-to-taipy` is a separate, unmerged change.
- Production must still pull the new `latest` after merge (verify host auto-redeploys).
- Docker Hub login runs for the first time post-fix; watch that step in case those secrets need attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image build-and-push workflow to use newer automation actions and a simpler registry login method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->