### PR TITLE
CI: publish to Docker Hub only, drop GHCR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
     "superpowers-developing-for-claude-code@superpowers-marketplace": true,
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true
   }
 }

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,6 @@ on:
   workflow_dispatch:
 
 env:
-  GHCR_IMAGE: ghcr.io/${{ github.repository }}
   DOCKERHUB_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/streamlit-network
 
 jobs:
@@ -18,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -28,13 +26,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
@@ -48,7 +39,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.GHCR_IMAGE }}
             ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Problem
After fixing the GHCR login and rotating the Docker Hub token, the build reached the push step and failed:

\`\`\`
failed to push ghcr.io/linehaul-ai/streamlit-network:latest: 403 Forbidden
\`\`\`

The org-level GHCR package isn't linked to this repository, so the built-in \`GITHUB_TOKEN\` (even with \`packages: write\`) can't push to it. This was hidden until now because PR runs use \`push: false\`.

## Fix
Production deploys from **Docker Hub** (Docker Swarm pulls Docker Hub); GHCR was never used. Remove it entirely:
- Drop the GHCR login step and \`GHCR_IMAGE\`.
- Publish only \`DOCKERHUB_IMAGE\` in metadata.
- Remove the now-unneeded \`packages: write\` permission.

Result: the workflow builds and pushes a single Docker Hub image on push to master — no GHCR permissions to manage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded AI assistant plugin support with an additional review plugin enabled.
* **Chores**
  * Simplified container image publishing to use Docker Hub only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->